### PR TITLE
fix: 修复默认器具选择导致的方案显示问题

### DIFF
--- a/src/lib/hooks/useBrewingState.ts
+++ b/src/lib/hooks/useBrewingState.ts
@@ -16,7 +16,7 @@ import { getMainTabPreference, saveMainTabPreference } from "@/lib/navigation/na
 
 // 器具选择缓存
 const MODULE_NAME = 'brewing-equipment';
-const DEFAULT_EQUIPMENT = 'v60';
+const DEFAULT_EQUIPMENT = 'V60';
 
 export const getSelectedEquipmentPreference = (): string => {
     return getStringState(MODULE_NAME, 'selectedEquipment', DEFAULT_EQUIPMENT);


### PR DESCRIPTION
## 问题描述

用户反映在首次使用应用时，会出现"当前器具暂无自定义方案，请点击下方按钮添加"的错误提示，但实际上V60器具应该有默认的通用方案可用。

## 问题原因

在 `useBrewingState.ts` 中，默认器具设置存在大小写不一致的问题：
- `DEFAULT_EQUIPMENT` 被设置为 `'v60'`（小写）
- 但在 `config.ts` 中，V60器具的ID和通用方案的键都是 `'V60'`（大写）
- 这导致键不匹配，系统找不到V60对应的通用方案

## 解决方案

将 `DEFAULT_EQUIPMENT` 从 `'v60'` 修改为 `'V60'`，确保默认器具选择与配置文件中的键保持一致。

## 修复效果

- ✅ 修复了"当前器具暂无自定义方案"的错误提示
- ✅ V60器具现在能正确显示通用方案（一刀流、三段式、粕谷哲4:6法等）
- ✅ 用户首次使用应用时能立即看到可用的冲煮方案
- ✅ 确保了默认器具选择的一致性

## 测试

- [x] 验证V60器具能正确加载通用方案
- [x] 确认不再显示错误的空方案提示
- [x] 检查器具选择缓存功能正常工作

## 变更文件

- `src/lib/hooks/useBrewingState.ts`: 修复默认器具选择的大小写问题

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author