### PR TITLE
修复：咖啡豆批量导入时不会及时刷新咖啡豆列表

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1064,7 +1064,33 @@ const PourOverRecipes = ({ initialHasBeans }: { initialHasBeans: boolean }) => {
             // 关闭导入表单
             setShowImportBeanForm(false);
 
-            // 更新咖啡豆状态
+            // 触发统一的数据更新事件机制，确保咖啡豆列表及时刷新
+            // 1. 清除CoffeeBeanManager的缓存，确保获取最新数据
+            CoffeeBeanManager.clearCache();
+
+            // 2. 触发咖啡豆数据变更事件，让所有相关组件监听并更新
+            window.dispatchEvent(
+                new CustomEvent('coffeeBeanDataChanged', {
+                    detail: {
+                        action: 'batchImport',
+                        importCount: importCount,
+                        lastBeanId: lastImportedBean?.id
+                    }
+                })
+            );
+
+            // 3. 触发咖啡豆列表变化事件，确保所有监听器都能收到通知
+            window.dispatchEvent(
+                new CustomEvent('coffeeBeanListChanged', {
+                    detail: {
+                        hasBeans: true,
+                        batchImport: true,
+                        importCount: importCount
+                    }
+                })
+            );
+
+            // 4. 更新咖啡豆状态
             handleBeanListChange();
 
             // 切换到咖啡豆标签页，跳过过渡动画

--- a/src/components/coffee-bean/List/index.tsx
+++ b/src/components/coffee-bean/List/index.tsx
@@ -278,8 +278,8 @@ const CoffeeBeans: React.FC<CoffeeBeansProps> = ({
     // 监听统一的咖啡豆数据更新事件
     useEffect(() => {
         const handleCoffeeBeanDataChanged = async (event: CustomEvent) => {
-            const { action, beanId } = event.detail;
-            console.log('咖啡豆数据变更事件:', { action, beanId });
+            const { action, beanId, importCount } = event.detail;
+            console.log('咖啡豆数据变更事件:', { action, beanId, importCount });
 
             // 清除CoffeeBeanManager的缓存，确保获取最新数据
             CoffeeBeanManager.clearCache();
@@ -290,6 +290,11 @@ const CoffeeBeans: React.FC<CoffeeBeansProps> = ({
                 setBeans(loadedBeans);
                 globalCache.beans = loadedBeans;
                 updateFilteredBeansAndCategories(loadedBeans);
+
+                // 如果是批量导入，显示成功提示
+                if (action === 'batchImport' && importCount) {
+                    console.log(`批量导入成功：已导入 ${importCount} 个咖啡豆`);
+                }
             } catch (error) {
                 console.error("重新加载咖啡豆数据失败:", error);
             }


### PR DESCRIPTION
## 问题描述

咖啡豆批量导入完成后，咖啡豆列表不会自动刷新显示新导入的咖啡豆，需要手动刷新页面才能看到新增的咖啡豆。

## 问题原因

批量导入咖啡豆时，虽然调用了 `handleBeanListChange()` 来更新状态，但没有触发统一的数据更新事件机制，导致咖啡豆列表组件无法及时收到数据变更通知。

## 修复内容

### 1. 在批量导入完成后添加统一的数据更新事件机制

在 `src/app/page.tsx` 的批量导入处理函数中：
- 清除 CoffeeBeanManager 的缓存
- 触发 `coffeeBeanDataChanged` 事件，通知所有相关组件数据已更新
- 触发 `coffeeBeanListChanged` 事件，确保列表组件收到通知
- 调用 `handleBeanListChange()` 更新应用状态

### 2. 增强咖啡豆列表组件的事件处理

在 `src/components/coffee-bean/List/index.tsx` 中：
- 增强了 `coffeeBeanDataChanged` 事件处理器，使其能够正确处理批量导入的情况
- 添加了对 `importCount` 参数的支持，用于记录导入的咖啡豆数量

## 修复后的效果

- ✅ 批量导入后咖啡豆列表会立即刷新显示新导入的咖啡豆
- ✅ 不需要手动刷新页面
- ✅ 保持了与单个添加咖啡豆时相同的数据更新机制
- ✅ 所有相关组件都能及时收到数据变更通知

## 技术细节

修复后的批量导入流程：

1. 循环添加每个咖啡豆到数据库
2. 关闭导入表单
3. **清除 CoffeeBeanManager 缓存**（确保获取最新数据）
4. **触发 `coffeeBeanDataChanged` 事件**（通知列表组件重新加载数据）
5. **触发 `coffeeBeanListChanged` 事件**（确保所有监听器收到通知）
6. 调用 `handleBeanListChange()` 更新应用状态
7. 切换到咖啡豆标签页

## 测试建议

1. 进行批量导入咖啡豆操作
2. 验证导入完成后列表是否自动刷新
3. 确认新导入的咖啡豆立即显示在列表中
4. 验证不需要手动刷新页面

## 相关文件

- `src/app/page.tsx` - 批量导入处理逻辑
- `src/components/coffee-bean/List/index.tsx` - 咖啡豆列表组件事件处理

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author